### PR TITLE
[SC]: Add a given `walletAddress` as an argument to the `getNullifiersByDomainAndWalletAddress()`, which also replace a `msg.sender` in the same function

### DIFF
--- a/contracts/src/circuits/zk-jwt/ZkJwtProofManager.sol
+++ b/contracts/src/circuits/zk-jwt/ZkJwtProofManager.sol
@@ -89,15 +89,15 @@ contract ZkJwtProofManager {
     /**
      * @notice - Retrieve the nullifierHash by a caller's wallet address and domain.
      */
-    function getNullifiersByDomainAndWalletAddress(string memory domain) public view returns (bytes32 _nullifierHash) {
-        return nullifiersByDomainAndWalletAddresses[domain][msg.sender];
+    function getNullifiersByDomainAndWalletAddress(string memory domain, address walletAddress) public view returns (bytes32 _nullifierHash) {
+        return nullifiersByDomainAndWalletAddresses[domain][walletAddress];
     }
 
     /**
      * @notice - Retrieve the nullifierHash by a caller's wallet address, domain, email hash.
      */
-    function getNullifiersByDomainAndEmailHashAndWalletAddress(string memory domain, string memory emailHash) public view returns (bytes32 _nullifierHash) {
-        return nullifiersByDomainAndEmailHashAndWalletAddresses[domain][emailHash][msg.sender];
+    function getNullifiersByDomainAndEmailHashAndWalletAddress(string memory domain, string memory emailHash, address walletAddress) public view returns (bytes32 _nullifierHash) {
+        return nullifiersByDomainAndEmailHashAndWalletAddresses[domain][emailHash][walletAddress];
     }
 
     /**


### PR DESCRIPTION
## Updated SC address

- Only `ZK_JWT_PROOF_MANAGER` is updated to `"0x2da863581b094109C007F0b6d2A5941D491483A0"` on Base Mainnet:
```bash
HONK_VERIFIER_ON_BASE_MAINNET="0xE82595069b66064345f8EeB162e3c4e2F4cED704"
ZK_JWT_PROOF_VERIFIER_ON_BASE_MAINNET="0xED169AF4E8d68d167B8c7bf66f241f30B8cA8083"
ZK_JWT_PROOF_MANAGER_ON_BASE_MAINNET="0x2da863581b094109C007F0b6d2A5941D491483A0"
#ZK_JWT_PROOF_MANAGER_ON_BASE_MAINNET="0x27F7e8088C68226E94cb540e412f3e144d1C72dD"
#ZK_JWT_PROOF_MANAGER_ON_BASE_MAINNET="0x3D40320EeAfb2f21CB4dDC240264405Be27A67AC"
```